### PR TITLE
Fix initial render of complex viewData.

### DIFF
--- a/packages/reactive_flutter_typeahead/lib/src/reactive_cupertino_typeahead.dart
+++ b/packages/reactive_flutter_typeahead/lib/src/reactive_cupertino_typeahead.dart
@@ -136,6 +136,7 @@ class ReactiveCupertinoTypeAhead<T, V> extends ReactiveFormField<T, V> {
           formControlName: formControlName,
           valueAccessor: valueAccessor,
           validationMessages: validationMessages,
+          stringify: stringify,
           showErrors: showErrors,
           builder: (field) {
             final state = field as _ReactiveCupertinoTypeAheadState<T, V>;
@@ -203,7 +204,11 @@ class _ReactiveCupertinoTypeAheadState<T, V>
 
     final initialValue = value;
     _textController = TextEditingController(
-        text: initialValue == null ? '' : initialValue.toString());
+        text: initialValue == null
+            ? ''
+            : widget.stringify == null
+                ? initialValue.toString()
+                : widget.stringify!(initialValue));
   }
 
   @override

--- a/packages/reactive_flutter_typeahead/lib/src/reactive_typeahead.dart
+++ b/packages/reactive_flutter_typeahead/lib/src/reactive_typeahead.dart
@@ -136,6 +136,7 @@ class ReactiveTypeAhead<T, V> extends ReactiveFormField<T, V> {
           valueAccessor: valueAccessor,
           validationMessages: validationMessages,
           showErrors: showErrors,
+          stringify: stringify,
           builder: (field) {
             final state = field as _ReactiveTypeaheadState<T, V>;
             final effectiveDecoration = textFieldConfiguration.decoration
@@ -184,7 +185,6 @@ class ReactiveTypeAhead<T, V> extends ReactiveFormField<T, V> {
             );
           },
         );
-
   @override
   ReactiveFormFieldState<T, V> createState() => _ReactiveTypeaheadState<T, V>();
 }
@@ -202,7 +202,11 @@ class _ReactiveTypeaheadState<T, V> extends ReactiveFormFieldState<T, V> {
 
     final initialValue = value;
     _textController = TextEditingController(
-        text: initialValue == null ? '' : initialValue.toString());
+        text: initialValue == null
+            ? ''
+            : widget.stringify == null
+                ? initialValue.toString()
+                : widget.stringify!(initialValue));
   }
 
   @override


### PR DESCRIPTION
Requires https://github.com/joanpablo/reactive_forms/pull/304

The initial value is render as stringified value instead of toString value
when a complex viewData is used