### PR TITLE
bumped pinput and updated smsCodeMatcher to non-nullable

### DIFF
--- a/packages/reactive_pinput/lib/reactive_pinput.dart
+++ b/packages/reactive_pinput/lib/reactive_pinput.dart
@@ -138,7 +138,7 @@ class ReactivePinPut<T> extends ReactiveFormField<T, String> {
     bool toolbarEnabled = true,
     bool readOnly = false,
     bool forceErrorState = false,
-    String? smsCodeMatcher = '\\d{4,7}',
+    String smsCodeMatcher = '\\d{4,7}',
     ValueChanged<String>? onCompleted,
     ValueChanged<String>? onSubmitted,
     VoidCallback? onLongPress,

--- a/packages/reactive_pinput/pubspec.yaml
+++ b/packages/reactive_pinput/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   reactive_forms: ^13.0.0
-  pinput: ^2.2.9
+  pinput: ^2.2.11
   smart_auth: ^1.0.5
 
 dev_dependencies:
@@ -24,7 +24,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
 # To add assets to your package, add an assets section, like this:
 # assets:
 #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
Pinput was recently updated to accept a non-nullable String smsCodeMatcher. This PR is to bump the version of pinput in the dependencies of reactive_pinput and make the smsCodeMatcher of type String (non-nullable)
