### PR TITLE
Add generic type to _MultiFile

### DIFF
--- a/packages/reactive_file_picker/lib/multi_file.dart
+++ b/packages/reactive_file_picker/lib/multi_file.dart
@@ -10,5 +10,5 @@ class MultiFile<T> with _$MultiFile<T> {
   const factory MultiFile({
     @Default([]) List<T> files,
     @Default([]) List<PlatformFile> platformFiles,
-  }) = _MultiFile;
+  }) = _MultiFile<T>;
 }


### PR DESCRIPTION
Private type `_MultiFile` does not receive the generic type T, causing IDEs to complain, even though the code is compiling and working properly.