### PR TITLE
Upgrading reactive forms for some packages

### DIFF
--- a/packages/reactive_advanced_switch/CHANGELOG.md
+++ b/packages/reactive_advanced_switch/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.6.2]
+* package version bump
+
 ## [0.6.1]
 * fix for https://github.com/artflutter/reactive_forms_widgets/issues/91
 

--- a/packages/reactive_advanced_switch/example/pubspec.yaml
+++ b/packages/reactive_advanced_switch/example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
   reactive_advanced_switch:
     path: ../
 

--- a/packages/reactive_advanced_switch/pubspec.yaml
+++ b/packages/reactive_advanced_switch/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_advanced_switch
 description: Wrapper around advanced_switch to use with reactive_forms.
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/artflutter/reactive_forms_widgets/tree/master/packages/reactive_advanced_switch
 issue_tracker: https://github.com/artflutter/reactive_forms_widgets/issues
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
   flutter_advanced_switch: ^3.0.1
 
 dev_dependencies:

--- a/packages/reactive_date_range_picker/CHANGELOG.md
+++ b/packages/reactive_date_range_picker/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.6.1]
+* package version bump
+
 ## [0.6.0]
 * package version bump
 

--- a/packages/reactive_date_range_picker/example/pubspec.yaml
+++ b/packages/reactive_date_range_picker/example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
   reactive_date_range_picker:
     path: ../
 

--- a/packages/reactive_date_range_picker/pubspec.yaml
+++ b/packages/reactive_date_range_picker/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_date_range_picker
 description: Wrapper around flutter showDateRangePicker to use with reactive_forms
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/artflutter/reactive_forms_widgets/tree/master/packages/reactive_date_range_picker
 issue_tracker: https://github.com/artflutter/reactive_forms_widgets/issues
 
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.18.0
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/reactive_date_time_picker/CHANGELOG.md
+++ b/packages/reactive_date_time_picker/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.6.2]
+* package version bump
+
 ## [0.6.1]
 * fix https://github.com/artflutter/reactive_forms_widgets/issues/82
 

--- a/packages/reactive_date_time_picker/example/pubspec.yaml
+++ b/packages/reactive_date_time_picker/example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
   reactive_date_time_picker:
     path: ../
 

--- a/packages/reactive_date_time_picker/pubspec.yaml
+++ b/packages/reactive_date_time_picker/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_date_time_picker
 description: Wrapper around showDatePicker and showTimePicker to work with reactive_forms
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/artflutter/reactive_forms_widgets/tree/master/packages/reactive_date_time_picker
 issue_tracker: https://github.com/artflutter/reactive_forms_widgets/issues
 
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.18.0
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/reactive_image_picker/CHANGELOG.md
+++ b/packages/reactive_image_picker/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.1]
+* package version bump
+
 ## [2.0.0]
 * refactoring
 * image, image gallery, multi image gallery, video, gallery video support

--- a/packages/reactive_image_picker/example/pubspec.yaml
+++ b/packages/reactive_image_picker/example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.3.0
+  reactive_forms: ^15.0.0
   app_settings: ^4.2.0
   reactive_image_picker:
     path: ../

--- a/packages/reactive_image_picker/pubspec.yaml
+++ b/packages/reactive_image_picker/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_image_picker
 description: Wrapper around image_picker to work with reactive_forms
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/artflutter/reactive_forms_widgets/tree/master/packages/reactive_image_picker
 issue_tracker: https://github.com/artflutter/reactive_forms_widgets/issues
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.3.0
+  reactive_forms: ^15.0.0
   freezed_annotation: ^2.2.0
   image_picker: ^0.8.7+4
   app_settings: ^4.2.0

--- a/packages/reactive_segmented_control/CHANGELOG.md
+++ b/packages/reactive_segmented_control/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.6.1]
+* package version bump
+
 ## [0.6.0]
 * package version bump
 

--- a/packages/reactive_segmented_control/example/pubspec.yaml
+++ b/packages/reactive_segmented_control/example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
   reactive_segmented_control:
     path: ../
 

--- a/packages/reactive_segmented_control/pubspec.yaml
+++ b/packages/reactive_segmented_control/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_segmented_control
 description: Wrapper around CupertinoSegmentedControl to use with reactive_forms
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/artflutter/reactive_forms_widgets/tree/master/packages/reactive_segmented_control
 issue_tracker: https://github.com/artflutter/reactive_forms_widgets/issues
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  reactive_forms: ^14.2.0
+  reactive_forms: ^15.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This is being done in an effort to resolve https://github.com/goxiaoy/flutter_survey_js/issues/87 without having to use `dependency_overrides:`.