### PR TITLE
Add `autocompleteOnSubmit` property to `reactive_raw_autocomplete`.

### DIFF
--- a/packages/reactive_raw_autocomplete/example/lib/main.dart
+++ b/packages/reactive_raw_autocomplete/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:reactive_raw_autocomplete/reactive_raw_autocomplete.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+import 'package:reactive_raw_autocomplete/reactive_raw_autocomplete.dart';
 
 void main() {
   runApp(const MyApp());
@@ -51,9 +51,13 @@ class MyApp extends StatelessWidget {
                               .contains(textEditingValue.text.toLowerCase());
                         });
                       },
+                      autocompleteOnSubmit: true,
                       optionsViewBuilder: (BuildContext context,
                           AutocompleteOnSelected<String> onSelected,
                           Iterable<String> options) {
+                        final selectedIndex =
+                            AutocompleteHighlightedOption.of(context);
+
                         return Align(
                           alignment: Alignment.topLeft,
                           child: Material(
@@ -72,6 +76,7 @@ class MyApp extends StatelessWidget {
                                     },
                                     child: ListTile(
                                       title: Text(option),
+                                      selected: selectedIndex == index,
                                     ),
                                   );
                                 },

--- a/packages/reactive_raw_autocomplete/lib/reactive_raw_autocomplete.dart
+++ b/packages/reactive_raw_autocomplete/lib/reactive_raw_autocomplete.dart
@@ -117,6 +117,7 @@ class ReactiveRawAutocomplete<T, V extends Object>
     TextAlignVertical? textAlignVertical,
     bool autofocus = false,
     bool readOnly = false,
+    bool autocompleteOnSubmit = false,
     bool? showCursor,
     bool obscureText = false,
     String obscuringCharacter = '•',
@@ -222,8 +223,15 @@ class ReactiveRawAutocomplete<T, V extends Object>
                       expands: expands,
                       maxLength: maxLength,
                       onTap: onTap,
-                      onSubmitted:
-                          onSubmitted != null ? (_) => onSubmitted() : null,
+                      onSubmitted: (_) {
+                        if (autocompleteOnSubmit) {
+                          onFieldSubmitted();
+                        }
+
+                        if (onSubmitted != null) {
+                          onSubmitted();
+                        }
+                      },
                       onEditingComplete: onEditingComplete,
                       inputFormatters: inputFormatters,
                       enabled: field.control.enabled,


### PR DESCRIPTION
Hi, thank you for the great package.
Sorry for my poor English.

I have added the following features to the `reactive_raw_autocomplete` package.
 - Added `autocompleteOnSubmit` property to auto complete upon submit to support key shortcut operations.

I hope this will be useful to you.

![capture](https://github.com/artflutter/reactive_forms_widgets/assets/14286444/13abc5c7-0641-436a-8e02-523e6e0e50a2)
