### PR TITLE
ReactiveDatePickerField and ReactiveMonthPickerDialog onChanged Callback

### DIFF
--- a/packages/reactive_date_time_picker/lib/reactive_date_time_picker.dart
+++ b/packages/reactive_date_time_picker/lib/reactive_date_time_picker.dart
@@ -100,6 +100,9 @@ class ReactiveDateTimePicker extends ReactiveFormField<DateTime, String> {
     // time picker params
     TimePickerEntryMode timePickerEntryMode = TimePickerEntryMode.dial,
     RouteSettings? timePickerRouteSettings,
+
+....// Events
+    ReactiveFormFieldCallback<DateTime>? onChanged,
   }) : super(
           key: key,
           formControl: formControl,
@@ -120,6 +123,7 @@ class ReactiveDateTimePicker extends ReactiveFormField<DateTime, String> {
                 onTap: () {
                   field.control.markAsTouched();
                   field.didChange(null);
+                  onChanged?.call(field.control);
                 },
               );
             }
@@ -215,6 +219,7 @@ class ReactiveDateTimePicker extends ReactiveFormField<DateTime, String> {
                             _combine(date, time),
                           ),
                         );
+                       onChanged?.call(field.control);
                       }
                     }
                     field.control.unfocus();

--- a/packages/reactive_month_picker_dialog/lib/reactive_month_picker_dialog.dart
+++ b/packages/reactive_month_picker_dialog/lib/reactive_month_picker_dialog.dart
@@ -100,6 +100,7 @@ class ReactiveMonthPickerDialog extends ReactiveFormField<DateTime, String> {
                 onTap: () {
                   field.control.markAsTouched();
                   field.didChange(null);
+                  onChanged?.call(field.control);
                 },
               );
             }

--- a/packages/reactive_month_picker_dialog/lib/reactive_month_picker_dialog.dart
+++ b/packages/reactive_month_picker_dialog/lib/reactive_month_picker_dialog.dart
@@ -70,13 +70,14 @@ class ReactiveMonthPickerDialog extends ReactiveFormField<DateTime, String> {
     Widget? confirmText,
     Widget? cancelText,
     double? customHeight,
-    double? customWidth,
+    double customWidth = 320,
     bool yearFirst = false,
     bool dismissible = false,
     double roundedCornersRadius = 0,
     bool forceSelectedDate = false,
     ButtonStyle? Function(DateTime)? monthStylePredicate,
     ButtonStyle? Function(int)? yearStylePredicate,
+    ReactiveFormFieldCallback<DateTime>? onChanged,
   }) : super(
           key: key,
           formControl: formControl,
@@ -148,6 +149,7 @@ class ReactiveMonthPickerDialog extends ReactiveFormField<DateTime, String> {
                         ? field.value
                         : field.valueAccessor.modelToViewValue(date),
                   );
+                  onChanged?.call(field.control);
                   field.control.markAsTouched();
                 },
                 child: InputDecorator(


### PR DESCRIPTION
Hi,

i added an `onChanged` Callback to `ReactiveDatePickerField` and `ReactiveMonthPickerDialog`

Because of `showMonthPicker` `customWidth` did not allow `double?` i changed `double? customWidth` to the default width of `showMonthPicker`.

I would appreciate if this pr would be approved and released.