### PR TITLE
ReactiveRawAutocomplete not setting correct displayValue

### DIFF
--- a/packages/reactive_raw_autocomplete/lib/reactive_raw_autocomplete.dart
+++ b/packages/reactive_raw_autocomplete/lib/reactive_raw_autocomplete.dart
@@ -336,7 +336,11 @@ class _ReactiveRawAutocompleteState<T, V extends Object>
 
   @override
   void onControlValueChanged(dynamic value) {
-    final effectiveValue = (value == null) ? '' : value.toString();
+    final widgetInstance = (widget as ReactiveRawAutocomplete<T, V>);
+
+    final effectiveValue = (value == null)
+        ? ''
+        : widgetInstance.displayStringForOption(value as V);
     _textController.value = _textController.value.copyWith(
       text: effectiveValue,
       selection: TextSelection.collapsed(offset: effectiveValue.length),


### PR DESCRIPTION
Hey! Thank you for this amazing library

Since I was having the very same problem mentioned by @ThomasDevApps, I decided to step in and try to fix it.
This occurs if you use custom models instead of a basic string: the displayStringForOption is not used when the value changes.

Fixes #134