### PR TITLE
Bump month_picker_dialog to 3.0.0

### DIFF
--- a/packages/reactive_month_picker_dialog/pubspec.yaml
+++ b/packages/reactive_month_picker_dialog/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_month_picker_dialog
 description: Wrapper around month_picker_dialog to use with reactive_forms.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/artflutter/reactive_forms_widgets/tree/master/packages/reactive_month_picker_dialog
 issue_tracker: https://github.com/artflutter/reactive_forms_widgets/issues
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  month_picker_dialog: ^2.11.2
+  month_picker_dialog: ^3.0.0
   reactive_forms: ">=16.0.0 <18.0.0"
   intl: ">=0.18.0 <1.0.0"
 
@@ -25,7 +25,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
 # To add assets to your package, add an assets section, like this:
 # assets:
 #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
Bump month_picker_dialog to 3.0.0 which bump intl to 0.19.0

Complete [changelog](https://pub.dev/packages/month_picker_dialog/changelog) from month_picker_dialog since last version
3.0.0
- Bumped intl to 0.19.0.
- Bumped flutter_lints to 4.0.0.

2.12.0
- Added buttonBorder: property to allow you define the border of the month/year buttons (default is const CircleBorder()) [#92](https://github.com/Macacoazul01/month_picker_dialog/pull/92).
- Added headerTitle: property to allow you add a custom title to the header of the dialog (default is null) [#92](https://github.com/Macacoazul01/month_picker_dialog/pull/92).