### PR TITLE
ReactiveCupertinoTypeAhead: use`formControl.field.enabled` instead of just `enabled` property

### DIFF
--- a/packages/reactive_flutter_typeahead/lib/src/reactive_cupertino_typeahead.dart
+++ b/packages/reactive_flutter_typeahead/lib/src/reactive_cupertino_typeahead.dart
@@ -162,7 +162,7 @@ class ReactiveCupertinoTypeAhead<T, V> extends ReactiveFormField<T, V> {
                 return CupertinoTextField(
                   controller: controller,
                   focusNode: focusNode,
-                  enabled: enabled,
+                  enabled: field.control.enabled,
                   decoration: decoration,
                   padding: padding,
                   placeholder: placeholder,


### PR DESCRIPTION
The field was using only the `enabled` property. This prevented it from listening to the state set by the form itself. This PR fixes it.
The Material variant already had it correctly