### PR TITLE
fix: add errorBuilder support to ReactivePinPut widget.

### DIFF
--- a/packages/reactive_pinput/lib/reactive_pinput.dart
+++ b/packages/reactive_pinput/lib/reactive_pinput.dart
@@ -154,6 +154,7 @@ class ReactivePinPut<T> extends ReactiveFormField<T, String> {
     EdgeInsets scrollPadding = const EdgeInsets.all(20),
     TapRegionCallback? onTapOutside,
     SmsRetriever? smsRetriever,
+    Widget Function(String?, String)? errorBuilder,
   }) : super(
           builder: (field) {
             final state = field as _ReactiveMacosTextFieldState<T>;
@@ -217,6 +218,7 @@ class ReactivePinPut<T> extends ReactiveFormField<T, String> {
               scrollPadding: scrollPadding,
               onTapOutside: onTapOutside,
               smsRetriever: smsRetriever,
+              errorBuilder: errorBuilder,
             );
           },
         );


### PR DESCRIPTION
Added support for custom error builder through errorBuilder parameter, which allows customizing validation error display in ReactivePinPut component.